### PR TITLE
feat: add support for examples

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -20,6 +20,7 @@ var (
 		RunE: func(cmd *cobra.Command, agrs []string) error {
 			return nil
 		},
+		Example: "mango --help",
 	}
 
 	oneCmd = &cobra.Command{

--- a/mcobra.go
+++ b/mcobra.go
@@ -27,9 +27,11 @@ func addCommandTree(m *mango.ManPage, c *cobra.Command, parent *mango.Command) e
 	if parent == nil {
 		// set root command
 		item = mango.NewCommand(c.Name(), "", "")
+		item.Example = c.Example
 		m.Root = *item
 	} else {
 		item = mango.NewCommand(c.Name(), c.Short, c.Use)
+		item.Example = c.Example
 		if err := parent.AddCommand(item); err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds support to add cobra command examples to the manpage. 

Ref: https://github.com/muesli/mango/pull/13